### PR TITLE
Update expressroute-locations.md

### DIFF
--- a/articles/expressroute/expressroute-locations.md
+++ b/articles/expressroute/expressroute-locations.md
@@ -99,8 +99,8 @@ The following table shows locations by service provider. If you want to view ava
 | **[Fibrenoire](https://fibrenoire.ca/en/services/cloudextn-2/)** | Supported | Supported | Montreal<br/>Quebec City<br/>Toronto2 |
 | **[GBI](https://www.gbiinc.com/microsoft-azure/)** | Supported | Supported | Dubai2<br/>Frankfurt |
 | **[GÉANT](https://www.geant.org/Networks)** | Supported | Supported | Amsterdam<br/>Amsterdam2<br/>Dublin<br/>Frankfurt<br/>Marseille |
-| **[GlobalConnect](https://www.globalconnect.no/tjenester/nettverk/cloud-access)** | Supported | Supported | Copenhagen<br/>Oslo<br/>Stavanger<br/>Stockholm | 
-| **[GlobalConnect DK](https://www.globalconnect.no/tjenester/nettverk/cloud-access)** | Supported | Supported | Amsterdam | 
+| **[GlobalConnect](https://www.globalconnect.no/tjenester/nettverk/cloud-access)** | Supported | Supported | Amsterdam<br/>Oslo<br/>Stavanger<br/>Stockholm | 
+| **[GlobalConnect DK](https://www.globalconnect.dk)** | Supported | Supported | Copenhagen | 
 | **GTT** |Supported |Supported | Amsterdam<br/>London2<br/>Washington DC |
 | **[Global Cloud Xchange (GCX)](https://globalcloudxchange.com/cloud-platform/cloud-x-fusion/)** | Supported| Supported | Chennai<br/>Mumbai |
 | **[iAdvantage](https://www.scx.sunevision.com/)** | Supported | Supported | Hong Kong2 |


### PR DESCRIPTION
The GlobalConnect express route links are not correct, the .dk should be labelled with Copenhagen not Amsterdam and Amsterdam should be put into the general GlobalConnect link location